### PR TITLE
add accessor to format day field in human readable format

### DIFF
--- a/app/DayCount.php
+++ b/app/DayCount.php
@@ -14,4 +14,9 @@ class DayCount extends Model
     protected $dates = [
         'day',
     ];
+
+    public function getDayAttribute($value)
+    {
+        return \Carbon\Carbon::parse($value)->isoFormat('MMMM Do YYYY');
+    }
 }


### PR DESCRIPTION
This PR does the following

- Adds accessor for the `day` field of `DayCount` Model to show up in iso format (to a more human-readable format).